### PR TITLE
Fix KeePass URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KeeShare
 
-KeeShare is a password sharing plugin for [KeePass](http://http://www.keepass.info/). It allows you share passwords with groups or individual users in a secure way.
+KeeShare is a password sharing plugin for [KeePass](http://www.keepass.info/). It allows you share passwords with groups or individual users in a secure way.
 
 ### LICENSE
 


### PR DESCRIPTION
URL is wrong and currently points to http//www.keepass.info/